### PR TITLE
Adding Media Pinkeye to Summary

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -39,6 +39,7 @@
        * [Embedable video](modules/media_entity/embeddable_video.md)
        * [Twitter](modules/media_entity/twitter.md)
        * [Instagram](modules/media_entity/instagram.md)
+   * [Media Pinkeye](modules/media_pinkeye/intro.md)
    * [Crop API](modules/crop/intro.md)
        * [Architecture](modules/crop/architecture.md)
        * [Implementation examples](modules/crop/Implementation_examples.md)


### PR DESCRIPTION
I've added Media Pineye to the ToC/Summary. I put this in a separate PR, as I'm wondering if we should re-order the Table of Contents/Summary by alphabetical order or perhaps by category (as in the modules folder). Unless someone is familiar with how the modules interrelate. Right now they might think that the ordering is arbitrary, which would be good to avoid.
